### PR TITLE
split up Makefile templates

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -5,4 +5,5 @@
 assignment_name = RBE_assignment_template
 export assignment_name
 
-include /usr/local/share/RBEassignment/assignment_builder.mk
+include /usr/local/share/RBEassignment/assignment.mk
+include /usr/local/share/RBEassignment/assignment_inst_clean.mk

--- a/example/RBE_assignment_template.pdf
+++ b/example/RBE_assignment_template.pdf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:784f12dcf835d6bd87ce7de2fb2869e5fd7eb8dbb1ed714dc6a604641340d801
-size 604319
+oid sha256:08820866ccf81c6cf7d995892c60c40086a703026e6361ba8bbe2aaa96e6346f
+size 604369

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,5 +14,9 @@ tlmgr conf texmf TEXMFLOCAL $(kpsewhich -var-value=TEXMFLOCAL)
 mktexlsr $(kpsewhich -var-value=TEXMFLOCAL)
 
 # Copy the Makefile to a central location
-mkdir -p /usr/local/share/RBEassignment
-cp -f template/assignment_builder.mk /usr/local/share/RBEassignment/
+MK_PATH=/usr/local/share/RBEassignment
+mkdir -p ${MK_PATH}
+cp -f template/assignment_diagrams.mk ${MK_PATH}
+cp -f template/assignment_inst_clean.mk ${MK_PATH}
+cp -f template/assignment_nobib.mk ${MK_PATH}
+cp -f template/assignment.mk ${MK_PATH}

--- a/template/assignment.mk
+++ b/template/assignment.mk
@@ -6,7 +6,6 @@ LATEX_BUILD = xelatex -shell-escape -interaction=nonstopmode -file-line-error
 
 all : document
 document: $(assignment_name).tex
-	find . -name "Makefile" -exec sh -c 'cd "$(dirname "$0")" && make' {} \;
 	$(LATEX_BUILD) $(assignment_name)
 	$(LATEX_BUILD) $(assignment_name)
 	makeindex $(assignment_name)-url
@@ -14,24 +13,3 @@ document: $(assignment_name).tex
 	bibtex $(assignment_name)
 	$(LATEX_BUILD) $(assignment_name)
 	$(LATEX_BUILD) $(assignment_name)
-
-
-install: document
-	cp -f $(assignment_name).pdf /output/
-
-clean :
-	rm -f $(assignment_name).pdf
-	rm -f *.out
-	rm -f *.log
-	rm -f *.aux
-	rm -f *.toc
-	rm -f *.lof
-	rm -f *.bbl
-	rm -f *.blg
-	rm -f *.vrb
-	rm -f *.nav
-	rm -f *.snm
-	rm -f *.idx
-	rm -f *.mst
-	rm -f *.ilg
-	rm -f *.ind

--- a/template/assignment_diagrams.mk
+++ b/template/assignment_diagrams.mk
@@ -1,0 +1,16 @@
+# Makefile for assignments
+# Date: 2025
+# Author: Daniel Montrallo Flickinger, PhD ; dflickinger@wpi.edu
+
+LATEX_BUILD = xelatex -shell-escape -interaction=nonstopmode -file-line-error
+
+all : document
+document: $(assignment_name).tex
+	$(MAKE) -C diagrams
+	$(LATEX_BUILD) $(assignment_name)
+	$(LATEX_BUILD) $(assignment_name)
+	makeindex $(assignment_name)-url
+	bibtex $(assignment_name)
+	bibtex $(assignment_name)
+	$(LATEX_BUILD) $(assignment_name)
+	$(LATEX_BUILD) $(assignment_name)

--- a/template/assignment_inst_clean.mk
+++ b/template/assignment_inst_clean.mk
@@ -1,0 +1,24 @@
+# Makefile for assignments - install and clean targets
+# Date: 2025
+# Author: Daniel Montrallo Flickinger, PhD ; dflickinger@wpi.edu
+
+
+install: document
+	cp -f $(assignment_name).pdf /output/
+
+clean :
+	rm -f $(assignment_name).pdf
+	rm -f *.out
+	rm -f *.log
+	rm -f *.aux
+	rm -f *.toc
+	rm -f *.lof
+	rm -f *.bbl
+	rm -f *.blg
+	rm -f *.vrb
+	rm -f *.nav
+	rm -f *.snm
+	rm -f *.idx
+	rm -f *.mst
+	rm -f *.ilg
+	rm -f *.ind

--- a/template/assignment_nobib.mk
+++ b/template/assignment_nobib.mk
@@ -1,0 +1,12 @@
+# Makefile for assignments
+# Date: 2025
+# Author: Daniel Montrallo Flickinger, PhD ; dflickinger@wpi.edu
+
+LATEX_BUILD = xelatex -shell-escape -interaction=nonstopmode -file-line-error
+
+all : document
+document: $(assignment_name).tex
+	$(LATEX_BUILD) $(assignment_name)
+	$(LATEX_BUILD) $(assignment_name)
+	makeindex $(assignment_name)-url
+	$(LATEX_BUILD) $(assignment_name)


### PR DESCRIPTION
Split up into bib/nobib and diagram builds. (Easier than trying to embed the logic in the Makefile itself.)